### PR TITLE
RenderAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ class UsersController
 end
 ```
 
+#### `ActionController::RenderAction`
+
+Adds support for calling views by their action name. So instead of this:
+
+```ruby
+class UsersController
+  def other_index
+    render Views::Users::Index.new
+  end
+end
+```
+
+You can do this:
+
+```ruby
+class UsersController
+  include Phlexible::Rails::ActionController::RenderAction
+
+  def other_index
+    render :index
+    # or render "users/index"
+  end
+end
+```
+
+Any other parameters passed will be passed as named parameters to the view's constructor.
+
 #### `ControllerVariables`
 
 > Available in **>= 1.0.0**

--- a/lib/phlexible/rails.rb
+++ b/lib/phlexible/rails.rb
@@ -15,6 +15,7 @@ module Phlexible
     module ActionController
       autoload :ImplicitRender, 'phlexible/rails/action_controller/implicit_render'
       autoload :MetaTags, 'phlexible/rails/action_controller/meta_tags'
+      autoload :RenderAction, 'phlexible/rails/action_controller/render_action'
     end
   end
 end

--- a/lib/phlexible/rails/action_controller/base.rb
+++ b/lib/phlexible/rails/action_controller/base.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Phlexible
+  module Rails
+    module ActionController
+      module Base
+
+        protected
+
+        def phlex_view(options)
+          phlex_view_path(options)&.camelize&.safe_constantize
+        end
+
+        def phlex_view_path(options)
+          if options[:action]
+            "/#{controller_path}/#{options[:action]}_view"
+          elsif options[:template]
+            "/#{options[:template]}_view"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/phlexible/rails/action_controller/implicit_render.rb
+++ b/lib/phlexible/rails/action_controller/implicit_render.rb
@@ -18,10 +18,15 @@
 #     include Phlexible::Rails::ActionController::ImplicitRender
 #   end
 #
+
+require_relative "base"
+
 module Phlexible
   module Rails
     module ActionController
       module ImplicitRender
+        include Base
+
         def default_render
           render_plex_view({ action: action_name }) || super
         end
@@ -40,19 +45,9 @@ module Phlexible
         def render_plex_view(options)
           options[:action] ||= action_name
 
-          return unless (view = phlex_view(options[:action]))
+          return unless (view = phlex_view({action: options[:action]}))
 
           render view.new, options
-        end
-
-        private
-
-        def phlex_view(action_name = @_action_name)
-          phlex_view_path(action_name).camelize.safe_constantize
-        end
-
-        def phlex_view_path(action_name)
-          "#{controller_path}/#{action_name}_view"
         end
       end
     end

--- a/lib/phlexible/rails/action_controller/render_action.rb
+++ b/lib/phlexible/rails/action_controller/render_action.rb
@@ -1,27 +1,19 @@
+# frozen_string_literal: true
+
+
+require_relative "base"
+
 module Phlexible
   module Rails
     module ActionController
       module RenderAction
+        include Base
 
         def render_to_body(options = {})
           if view = phlex_view(options)
             render view.new(**options.except(:action, :prefixes, :template, :layout))
           else
             super
-          end
-        end
-
-        private
-
-        def phlex_view(options)
-          phlex_view_path(options)&.camelize&.safe_constantize
-        end
-
-        def phlex_view_path(options)
-          if options[:action]
-            "/#{controller_path}/#{options[:action]}_view"
-          elsif options[:template]
-            "/#{options[:template]}_view"
           end
         end
       end

--- a/lib/phlexible/rails/action_controller/render_action.rb
+++ b/lib/phlexible/rails/action_controller/render_action.rb
@@ -1,0 +1,30 @@
+module Phlexible
+  module Rails
+    module ActionController
+      module RenderAction
+
+        def render_to_body(options = {})
+          if view = phlex_view(options)
+            render view.new(**options.except(:action, :prefixes, :template, :layout))
+          else
+            super
+          end
+        end
+
+        private
+
+        def phlex_view(options)
+          phlex_view_path(options)&.camelize&.safe_constantize
+        end
+
+        def phlex_view_path(options)
+          if options[:action]
+            "/#{controller_path}/#{options[:action]}_view"
+          elsif options[:template]
+            "/#{options[:template]}_view"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is only partway finished - it worked OK on its own but I couldn't get it to play ball with ImplicitRender loaded into the same controller. I thought you'd be interested in my partial work anyway in case you fancy adding a feature like this to Phlexible in the future.

Effectively, it allows (or should allow) calling `render :index` or `render "path/to/index"` to load the view in the same way that ImplicitRender does implicitly.

This was originally so I could get the Wicked gem to play ball, but in the end I ended up monkeypatching one of its methods to call one of your private methods, which was less code and easier to understand:

```ruby
  # Monkeypatch the wizard_value method. phlex_view is actually a private method
  # but it works well for converting action names to views - at least for now
  def wizard_value(step_name)
    orig = super(step_name)
    phlex_view(orig) || orig
  end
```

Thanks for all your work on this regardless!